### PR TITLE
Add test for mix question type in issue #53

### DIFF
--- a/tests/test_math_worksheet_generator.py
+++ b/tests/test_math_worksheet_generator.py
@@ -28,6 +28,19 @@ class TestStringMethods(unittest.TestCase):
         question = g.generate_question()
         self.assertEqual(question[0] / question[2], question[3])
 
+    def test_generate_question_mix(self):
+        g = Mg(type_='mix', max_number=9, question_count=10)
+        question = g.generate_question()
+        self.assertIn(question[1], ['+', '-', 'x', '/'])
+        if question[1] == '+':
+            self.assertEqual(question[0] + question[2], question[3])
+        elif question[1] == '-':
+            self.assertEqual(question[0] - question[2], question[3])
+        elif question[1] == 'x':
+            self.assertEqual(question[0] * question[2], question[3])
+        elif question[1] == '/':
+            self.assertEqual(question[0] / question[2], question[3])
+
     def test_generate_question_unsupport_type_(self):
         g = Mg(type_='p', max_number=9, question_count=10)
         with self.assertRaisesRegex(RuntimeError, expected_regex=r"Question main_type p not supported"):

--- a/tests/test_math_worksheet_generator.py
+++ b/tests/test_math_worksheet_generator.py
@@ -1,8 +1,9 @@
 import math
 import unittest
+from unittest.mock import patch
+import random
 
 from run import MathWorksheetGenerator as Mg
-
 
 class TestStringMethods(unittest.TestCase):
 
@@ -28,19 +29,6 @@ class TestStringMethods(unittest.TestCase):
         question = g.generate_question()
         self.assertEqual(question[0] / question[2], question[3])
 
-    def test_generate_question_mix(self):
-        g = Mg(type_='mix', max_number=9, question_count=10)
-        question = g.generate_question()
-        self.assertIn(question[1], ['+', '-', 'x', '/'])
-        if question[1] == '+':
-            self.assertEqual(question[0] + question[2], question[3])
-        elif question[1] == '-':
-            self.assertEqual(question[0] - question[2], question[3])
-        elif question[1] == 'x':
-            self.assertEqual(question[0] * question[2], question[3])
-        elif question[1] == '/':
-            self.assertEqual(question[0] / question[2], question[3])
-
     def test_generate_question_unsupport_type_(self):
         g = Mg(type_='p', max_number=9, question_count=10)
         with self.assertRaisesRegex(RuntimeError, expected_regex=r"Question main_type p not supported"):
@@ -50,6 +38,15 @@ class TestStringMethods(unittest.TestCase):
         g = Mg(type_='x', max_number=9, question_count=10)
         question_list = g.get_list_of_questions(g.question_count)
         self.assertEqual(len(question_list), g.question_count)
+
+    def test_get_list_of_questions_calls_random_choice_for_mix(self):
+        g = Mg(type_='mix', max_number=9, question_count=10)
+
+        with patch('random.choice', wraps=random.choice) as mock_choice:
+            g.get_list_of_questions(g.question_count)
+        
+        # random.choice should be called at least question_count times, or more when there are duplicates
+        self.assertGreaterEqual(mock_choice.call_count, g.question_count)
 
     def test_make_question_page_page_count(self):
         g = Mg(type_='x', max_number=9, question_count=2)


### PR DESCRIPTION
A new test **test_generate_question_mix()** has been added to test for mix type question, which is currently missing in the test cases.

Now there are 13 test cases, and the current version of run.py has passed the new test.

Testing screenshot:
<img width="522" height="88" alt="Screenshot 2025-10-30 at 17 19 00" src="https://github.com/user-attachments/assets/2d02b723-9d5e-4113-b31a-1dd23baf5b9d" />
